### PR TITLE
Fix TargetEncoder compatibility with Polars 1.30+

### DIFF
--- a/shirokumas/_target.py
+++ b/shirokumas/_target.py
@@ -13,8 +13,8 @@ from sklearn.model_selection import BaseCrossValidator
 from . import OutOfFoldEncodeWrapper
 from ._base import BaseEncoder
 
-_UNKNOWN_VALUE = -1
-_MISSING_VALUE = -2
+_UNKNOWN_VALUE = -1.0
+_MISSING_VALUE = -2.0
 
 
 class _GreedyTargetEncoder(BaseEncoder):


### PR DESCRIPTION
## Summary
• Fixed TypeError in TargetEncoder when using Polars 1.30+
• Changed `_UNKNOWN_VALUE` and `_MISSING_VALUE` constants from integers to floats
• Resolves issue with strict type checking in `replace_strict()` operation

## Test plan
- [x] All existing tests pass
- [x] Verified fix resolves the specific TypeError mentioned in issue #15
- [x] No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)